### PR TITLE
fix: module v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ keycloak is a Go client library for accessing the [Keycloak API](https://www.key
 ## Installation
 
 ```bash
-go get github.com/zemirco/keycloak
+go get github.com/zemirco/keycloak/v2
 ```
 
 ## Usage
@@ -23,7 +23,7 @@ package main
 import (
     "context"
 
-    "github.com/zemirco/keycloak"
+    "github.com/zemirco/keycloak/v2"
     "golang.org/x/oauth2"
 )
 

--- a/example_full_test.go
+++ b/example_full_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/zemirco/keycloak"
+	"github.com/zemirco/keycloak/v2"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/zemirco/keycloak"
+	"github.com/zemirco/keycloak/v2"
 	"golang.org/x/oauth2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zemirco/keycloak
+module github.com/zemirco/keycloak/v2
 
 go 1.17
 


### PR DESCRIPTION
fix issue:
```
github.com/zemirco/keycloak/v2@v2.0.0: go.mod has non-.../v2 module path "github.com/zemirco/keycloak" (and .../v2/go.mod does not exist) at revision v2.0.0
```